### PR TITLE
Event 기능 구현

### DIFF
--- a/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +27,12 @@ public class EventController {
             @RequestParam(defaultValue = "10") int size) {
         Page<EventResponseDto> events = eventService.getAllEvents(page, size);
         return ResponseEntity.ok(events);
+    }
+
+    @GetMapping("/{eventId}")
+    public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long eventId) {
+        EventResponseDto event = eventService.getEventById(eventId);
+        return ResponseEntity.ok(event);
     }
 
 }

--- a/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
@@ -3,6 +3,7 @@ package com.example.goorm_ticket.api.event.controller;
 import com.example.goorm_ticket.api.event.service.EventService;
 import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
 import com.example.goorm_ticket.domain.event.dto.SeatResponseDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -14,14 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 public class EventController {
 
     private final EventService eventService;
-
-    @Autowired
-    public EventController(EventService eventService) {
-        this.eventService = eventService;
-    }
 
     // 전체 페이지 이벤트 조회 API
     @GetMapping("/events")

--- a/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @RestController
 public class EventController {
@@ -36,8 +35,7 @@ public class EventController {
     // 이벤트ID로 상세 정보 조회
     @GetMapping("/events/{eventId}")
     public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long eventId) {
-        EventResponseDto event = eventService.getEventById(eventId)
-                .orElseThrow(() -> new NoSuchElementException("이벤트를 찾지 못했습니다. eventId: " + eventId));
+        EventResponseDto event = eventService.getEventById(eventId);
         return ResponseEntity.ok(event);
     }
 

--- a/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
@@ -21,7 +21,7 @@ public class EventController {
     private final EventService eventService;
 
     // 전체 페이지 이벤트 조회 API
-    @GetMapping("/events")
+    @GetMapping("/api/v1/events")
     public ResponseEntity<Page<EventResponseDto>> getAllEvents(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
@@ -30,14 +30,14 @@ public class EventController {
     }
 
     // 이벤트ID로 상세 정보 조회
-    @GetMapping("/events/{eventId}")
+    @GetMapping("/api/v1/events/{eventId}")
     public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long eventId) {
         EventResponseDto event = eventService.getEventById(eventId);
         return ResponseEntity.ok(event);
     }
 
     // 특정 이벤트의 전체 좌석을 조회하는 API
-    @GetMapping("/events/{eventId}/seats")
+    @GetMapping("/api/v1/events/{eventId}/seats")
     public ResponseEntity<List<SeatResponseDto>> getSeatsByEventId(@PathVariable("eventId") Long eventId) {
         List<SeatResponseDto> seats = eventService.getSeatsByEventId(eventId);
         return ResponseEntity.ok(seats);

--- a/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
@@ -2,6 +2,7 @@ package com.example.goorm_ticket.api.event.controller;
 
 import com.example.goorm_ticket.api.event.service.EventService;
 import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
+import com.example.goorm_ticket.domain.event.dto.SeatResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 public class EventController {
@@ -33,6 +36,13 @@ public class EventController {
     public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long eventId) {
         EventResponseDto event = eventService.getEventById(eventId);
         return ResponseEntity.ok(event);
+    }
+
+    // 특정 이벤트의 전체 좌석을 조회하는 API
+    @GetMapping("/events/{event_id}/seats")
+    public ResponseEntity<List<SeatResponseDto>> getSeatsByEventId(@PathVariable("event_id") Long eventId) {
+        List<SeatResponseDto> seats = eventService.getSeatsByEventId(eventId);
+        return ResponseEntity.ok(seats);
     }
 
 }

--- a/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @RestController
 public class EventController {
@@ -32,15 +33,17 @@ public class EventController {
         return ResponseEntity.ok(events);
     }
 
-    @GetMapping("/{eventId}")
+    // 이벤트ID로 상세 정보 조회
+    @GetMapping("/events/{eventId}")
     public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long eventId) {
-        EventResponseDto event = eventService.getEventById(eventId);
+        EventResponseDto event = eventService.getEventById(eventId)
+                .orElseThrow(() -> new NoSuchElementException("이벤트를 찾지 못했습니다. eventId: " + eventId));
         return ResponseEntity.ok(event);
     }
 
     // 특정 이벤트의 전체 좌석을 조회하는 API
-    @GetMapping("/events/{event_id}/seats")
-    public ResponseEntity<List<SeatResponseDto>> getSeatsByEventId(@PathVariable("event_id") Long eventId) {
+    @GetMapping("/events/{eventId}/seats")
+    public ResponseEntity<List<SeatResponseDto>> getSeatsByEventId(@PathVariable("eventId") Long eventId) {
         List<SeatResponseDto> seats = eventService.getSeatsByEventId(eventId);
         return ResponseEntity.ok(seats);
     }

--- a/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/controller/EventController.java
@@ -1,0 +1,31 @@
+package com.example.goorm_ticket.api.event.controller;
+
+import com.example.goorm_ticket.api.event.service.EventService;
+import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class EventController {
+
+    private final EventService eventService;
+
+    @Autowired
+    public EventController(EventService eventService) {
+        this.eventService = eventService;
+    }
+
+    // 전체 페이지 이벤트 조회 API
+    @GetMapping("/events")
+    public ResponseEntity<Page<EventResponseDto>> getAllEvents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<EventResponseDto> events = eventService.getAllEvents(page, size);
+        return ResponseEntity.ok(events);
+    }
+
+}

--- a/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
@@ -1,0 +1,38 @@
+package com.example.goorm_ticket.api.event.service;
+
+import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
+import com.example.goorm_ticket.domain.event.entity.Event;
+import com.example.goorm_ticket.domain.event.repository.EventRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    @Autowired
+    public EventService(EventRepository eventRepository) {
+        this.eventRepository = eventRepository;
+    }
+
+    // 페이징된 이벤트 리스트 조회, DTO 변환
+    public Page<EventResponseDto> getAllEvents(int page, int size) {
+        Page<Event> eventsPage = eventRepository.findAll(PageRequest.of(page, size));
+        List<EventResponseDto> dtoList = eventsPage.stream()
+                .map(event -> EventResponseDto.builder()
+                        .title(event.getTitle())
+                        .ticketOpenTime(event.getTicketOpenTime())
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(dtoList, eventsPage.getPageable(), eventsPage.getTotalElements());
+    }
+}

--- a/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
@@ -19,13 +19,13 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EventService {
 
     private final EventRepository eventRepository;
     private final SeatRepository seatRepository;
 
 
-    // 페이징된 이벤트 리스트 조회, DTO 변환
     public Page<EventResponseDto> getAllEvents(int page, int size) {
         Page<Event> eventsPage = eventRepository.findAll(PageRequest.of(page, size));
         List<EventResponseDto> dtoList = eventsPage.stream()
@@ -35,14 +35,12 @@ public class EventService {
         return new PageImpl<>(dtoList, eventsPage.getPageable(), eventsPage.getTotalElements());
     }
 
-    @Transactional(readOnly = true)
     public EventResponseDto getEventById(Long eventId) {
         return eventRepository.findById(eventId)
                 .map(EventResponseDto::mapToEventResponseDto)
                 .orElseThrow(() -> new NoSuchElementException("이벤트를 찾지 못했습니다. eventId: " + eventId));
     }
 
-    @Transactional(readOnly = true)
     public List<SeatResponseDto> getSeatsByEventId(Long eventId) {
         // 해당 이벤트가 존재하는지 확인
         Event event = eventRepository.findById(eventId)

--- a/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.data.domain.PageImpl;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -35,4 +36,15 @@ public class EventService {
 
         return new PageImpl<>(dtoList, eventsPage.getPageable(), eventsPage.getTotalElements());
     }
+
+    public EventResponseDto getEventById(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new NoSuchElementException("Event not found with id " + eventId));
+
+        return EventResponseDto.builder()
+                .title(event.getTitle())
+                .ticketOpenTime(event.getTicketOpenTime())
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
@@ -46,7 +46,7 @@ public class EventService {
     public List<SeatResponseDto> getSeatsByEventId(Long eventId) {
         // 해당 이벤트가 존재하는지 확인
         Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾지 못했습니다. eventId: " + eventId));
+                .orElseThrow(() -> new NoSuchElementException("이벤트를 찾지 못했습니다. eventId: " + eventId));
 
         // 해당 이벤트의 모든 좌석 조회
         List<Seat> seats = seatRepository.findByEvent(event);

--- a/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
@@ -1,27 +1,30 @@
 package com.example.goorm_ticket.api.event.service;
 
 import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
+import com.example.goorm_ticket.domain.event.dto.SeatResponseDto;
 import com.example.goorm_ticket.domain.event.entity.Event;
+import com.example.goorm_ticket.domain.event.entity.Seat;
 import com.example.goorm_ticket.domain.event.repository.EventRepository;
+import com.example.goorm_ticket.domain.event.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class EventService {
 
     private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
 
-    @Autowired
-    public EventService(EventRepository eventRepository) {
-        this.eventRepository = eventRepository;
-    }
 
     // 페이징된 이벤트 리스트 조회, DTO 변환
     public Page<EventResponseDto> getAllEvents(int page, int size) {
@@ -45,6 +48,24 @@ public class EventService {
                 .title(event.getTitle())
                 .ticketOpenTime(event.getTicketOpenTime())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<SeatResponseDto> getSeatsByEventId(Long eventId) {
+        // 해당 이벤트가 존재하는지 확인
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Event not found with id: " + eventId));
+
+        // 해당 이벤트의 모든 좌석 조회
+        List<Seat> seats = seatRepository.findByEvent(event);
+
+        // Seat 엔티티를 SeatResponseDto로 변환하여 반환
+        return seats.stream()
+                .map(seat -> SeatResponseDto.builder()
+                        .seatNumber(seat.getSeatNumber())
+                        .seatStatus(seat.getSeatStatus())
+                        .build())
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
@@ -7,7 +7,6 @@ import com.example.goorm_ticket.domain.event.entity.Seat;
 import com.example.goorm_ticket.domain.event.repository.EventRepository;
 import com.example.goorm_ticket.domain.event.repository.SeatRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,8 +29,7 @@ public class EventService {
     public Page<EventResponseDto> getAllEvents(int page, int size) {
         Page<Event> eventsPage = eventRepository.findAll(PageRequest.of(page, size));
         List<EventResponseDto> dtoList = eventsPage.stream()
-                .map(event -> mapToEventResponseDto(event)
-                )
+                .map(EventResponseDto::mapToEventResponseDto)
                 .collect(Collectors.toList());
 
         return new PageImpl<>(dtoList, eventsPage.getPageable(), eventsPage.getTotalElements());
@@ -41,7 +38,7 @@ public class EventService {
     @Transactional(readOnly = true)
     public EventResponseDto getEventById(Long eventId) {
         return eventRepository.findById(eventId)
-                .map(this::mapToEventResponseDto)
+                .map(EventResponseDto::mapToEventResponseDto)
                 .orElseThrow(() -> new NoSuchElementException("이벤트를 찾지 못했습니다. eventId: " + eventId));
     }
 
@@ -61,13 +58,6 @@ public class EventService {
                         .seatStatus(seat.getSeatStatus())
                         .build())
                 .collect(Collectors.toList());
-    }
-
-    private EventResponseDto mapToEventResponseDto(Event event) {
-        return EventResponseDto.builder()
-                .title(event.getTitle())
-                .ticketOpenTime(event.getTicketOpenTime())
-                .build();
     }
 
 }

--- a/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
+++ b/src/main/java/com/example/goorm_ticket/api/event/service/EventService.java
@@ -38,9 +38,11 @@ public class EventService {
         return new PageImpl<>(dtoList, eventsPage.getPageable(), eventsPage.getTotalElements());
     }
 
-    public Optional<EventResponseDto> getEventById(Long eventId) {
+    @Transactional(readOnly = true)
+    public EventResponseDto getEventById(Long eventId) {
         return eventRepository.findById(eventId)
-                .map(this::mapToEventResponseDto);
+                .map(this::mapToEventResponseDto)
+                .orElseThrow(() -> new NoSuchElementException("이벤트를 찾지 못했습니다. eventId: " + eventId));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/goorm_ticket/domain/event/dto/EventResponseDto.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/dto/EventResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.goorm_ticket.domain.event.dto;
 
+import com.example.goorm_ticket.domain.event.entity.Event;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,5 +19,12 @@ public class EventResponseDto {
     private EventResponseDto(String title, LocalDateTime ticketOpenTime) {
         this.title = title;
         this.ticketOpenTime = ticketOpenTime;
+    }
+
+    public static EventResponseDto mapToEventResponseDto(Event event) {
+        return EventResponseDto.builder()
+                .title(event.getTitle())
+                .ticketOpenTime(event.getTicketOpenTime())
+                .build();
     }
 }

--- a/src/main/java/com/example/goorm_ticket/domain/event/dto/EventResponseDto.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/dto/EventResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.goorm_ticket.domain.event.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class EventResponseDto {
+
+    private String title;
+    private LocalDateTime ticketOpenTime;
+
+    @Builder
+    private EventResponseDto(String title, LocalDateTime ticketOpenTime) {
+        this.title = title;
+        this.ticketOpenTime = ticketOpenTime;
+    }
+}

--- a/src/main/java/com/example/goorm_ticket/domain/event/dto/EventResponseDto.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/dto/EventResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.goorm_ticket.domain.event.dto;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,7 +8,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventResponseDto {
 
     private String title;

--- a/src/main/java/com/example/goorm_ticket/domain/event/dto/SeatResponseDto.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/dto/SeatResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.goorm_ticket.domain.event.dto;
+
+import com.example.goorm_ticket.domain.event.entity.SeatStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatResponseDto {
+    private Long seatNumber;
+    private SeatStatus seatStatus;
+
+    @Builder
+    private SeatResponseDto(Long seatNumber, SeatStatus seatStatus) {
+        this.seatNumber = seatNumber;
+        this.seatStatus = seatStatus;
+    }
+}

--- a/src/main/java/com/example/goorm_ticket/domain/event/entity/Seat.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/entity/Seat.java
@@ -20,22 +20,22 @@ public class Seat {
     private Long seatNumber;
 
     @Column(nullable = false)
-    private Long seatSection;
+    private String seatSection;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SeatStatus seatStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id", nullable = false)
+    @JoinColumn(name = "order_id")
     private Order order;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
     private Event event;
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private Seat(Long seatNumber, Long seatSection, SeatStatus seatStatus, Order order, Event event) {
+    @Builder
+    private Seat(Long seatNumber, String seatSection, SeatStatus seatStatus, Order order, Event event) {
         this.seatNumber = seatNumber;
         this.seatSection = seatSection;
         this.seatStatus = seatStatus;

--- a/src/main/java/com/example/goorm_ticket/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.example.goorm_ticket.domain.event.repository;
+
+import com.example.goorm_ticket.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/example/goorm_ticket/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/repository/EventRepository.java
@@ -2,6 +2,8 @@ package com.example.goorm_ticket.domain.event.repository;
 
 import com.example.goorm_ticket.domain.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 }

--- a/src/main/java/com/example/goorm_ticket/domain/event/repository/SeatRepository.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/repository/SeatRepository.java
@@ -1,0 +1,11 @@
+package com.example.goorm_ticket.domain.event.repository;
+
+import com.example.goorm_ticket.domain.event.entity.Event;
+import com.example.goorm_ticket.domain.event.entity.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+    List<Seat> findByEvent(Event event);
+}

--- a/src/main/java/com/example/goorm_ticket/domain/event/repository/SeatRepository.java
+++ b/src/main/java/com/example/goorm_ticket/domain/event/repository/SeatRepository.java
@@ -3,9 +3,11 @@ package com.example.goorm_ticket.domain.event.repository;
 import com.example.goorm_ticket.domain.event.entity.Event;
 import com.example.goorm_ticket.domain.event.entity.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface SeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByEvent(Event event);
 }

--- a/src/main/java/com/example/goorm_ticket/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/goorm_ticket/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.example.goorm_ticket.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import java.util.NoSuchElementException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("이벤트를 찾지 못했습니다. eventId: " + e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("잘못된 요청: " + e.getMessage());
+    }
+}

--- a/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
@@ -14,22 +14,19 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.*;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.mockito.Mockito;
 
 import org.springframework.test.web.servlet.ResultActions;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(EventController.class)
 //컨트롤러 통합테스트
@@ -83,6 +80,36 @@ class EventControllerTest {
     }
 
     @Test
+    void getEventById_NotFound() throws Exception {
+        // given
+        Long nonExistentEventId = 999L;
+        when(eventService.getEventById(nonExistentEventId))
+                .thenThrow(new NoSuchElementException(String.valueOf(nonExistentEventId)));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/events/" + nonExistentEventId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(content().string("이벤트를 찾지 못했습니다. eventId: 999"));
+    }
+
+    @Test
+    void getEventById_BadRequest() throws Exception {
+        // given
+        Long invalidEventId = -1L; // 유효하지 않은 ID 예시
+        when(eventService.getEventById(invalidEventId))
+                .thenThrow(new IllegalArgumentException("유효하지 않은 이벤트 ID입니다."));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/events/" + invalidEventId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("잘못된 요청: 유효하지 않은 이벤트 ID입니다.")); // 예상 메시지 검증
+    }
+
+    @Test
     @DisplayName("특정 이벤트의 좌석 조회 API 테스트")
     void getSeatsByEventId() throws Exception {
         // given
@@ -104,4 +131,5 @@ class EventControllerTest {
                 .andExpect(jsonPath("$[1].seatStatus", is(SeatStatus.RESERVED.toString())))
                 .andDo(print());
     }
+
 }

--- a/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 import org.springframework.test.web.servlet.ResultActions;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -72,10 +73,10 @@ class EventControllerTest {
                 .build();
 
         // when
-        when(eventService.getEventById(1L)).thenReturn(eventResponseDto);
+        when(eventService.getEventById(1L)).thenReturn(Optional.of(eventResponseDto));
 
         // then
-        mockMvc.perform(get("/1")
+        mockMvc.perform(get("/events/1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("Test Event"));

--- a/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
@@ -55,7 +55,7 @@ class EventControllerTest {
                 .thenReturn(new PageImpl<>(Collections.singletonList(eventResponseDto)));
 
         // then
-        mockMvc.perform(get("/events")
+        mockMvc.perform(get("/api/v1/events")
                         .param("page", "0")
                         .param("size", "10")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -76,7 +76,7 @@ class EventControllerTest {
         when(eventService.getEventById(1L)).thenReturn(eventResponseDto);
 
         // then
-        mockMvc.perform(get("/events/1")
+        mockMvc.perform(get("/api/v1/events/1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("Test Event"));
@@ -94,7 +94,7 @@ class EventControllerTest {
         Mockito.when(eventService.getSeatsByEventId(anyLong())).thenReturn(seatList);
 
         // then
-        mockMvc.perform(get("/events/1/seats")
+        mockMvc.perform(get("/api/v1/events/1/seats")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)))

--- a/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
@@ -73,7 +73,7 @@ class EventControllerTest {
                 .build();
 
         // when
-        when(eventService.getEventById(1L)).thenReturn(Optional.of(eventResponseDto));
+        when(eventService.getEventById(1L)).thenReturn(eventResponseDto);
 
         // then
         mockMvc.perform(get("/events/1")

--- a/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
@@ -1,0 +1,106 @@
+package com.example.goorm_ticket.api.event.controller;
+
+import com.example.goorm_ticket.api.event.service.EventService;
+import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
+import com.example.goorm_ticket.domain.event.dto.SeatResponseDto;
+import com.example.goorm_ticket.domain.event.entity.SeatStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.mockito.Mockito;
+
+import org.springframework.test.web.servlet.ResultActions;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+@WebMvcTest(EventController.class)
+//컨트롤러 통합테스트
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EventService eventService;
+
+    @Test
+    @DisplayName("전체 이벤트 조회 API 테스트")
+    void getAllEvents() throws Exception {
+        // given
+        EventResponseDto eventResponseDto = EventResponseDto.builder()
+                .title("Test Event")
+                .ticketOpenTime(LocalDateTime.now())
+                .build();
+
+        // when
+        when(eventService.getAllEvents(0, 10))
+                .thenReturn(new PageImpl<>(Collections.singletonList(eventResponseDto)));
+
+        // then
+        mockMvc.perform(get("/events")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].title").value("Test Event"));
+    }
+
+    @Test
+    @DisplayName("특정 이벤트 조회 API 테스트")
+    void getEventById() throws Exception {
+        // given
+        EventResponseDto eventResponseDto = EventResponseDto.builder()
+                .title("Test Event")
+                .ticketOpenTime(LocalDateTime.now())
+                .build();
+
+        // when
+        when(eventService.getEventById(1L)).thenReturn(eventResponseDto);
+
+        // then
+        mockMvc.perform(get("/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Test Event"));
+    }
+
+    @Test
+    @DisplayName("특정 이벤트의 좌석 조회 API 테스트")
+    void getSeatsByEventId() throws Exception {
+        // given
+        SeatResponseDto seat1 = SeatResponseDto.builder().seatNumber(1L).seatStatus(SeatStatus.AVAILABLE).build();
+        SeatResponseDto seat2 = SeatResponseDto.builder().seatNumber(2L).seatStatus(SeatStatus.RESERVED).build();
+        List<SeatResponseDto> seatList = Arrays.asList(seat1, seat2);
+
+        // when
+        Mockito.when(eventService.getSeatsByEventId(anyLong())).thenReturn(seatList);
+
+        // then
+        mockMvc.perform(get("/events/1/seats")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].seatNumber", is(1)))
+                .andExpect(jsonPath("$[0].seatStatus", is(SeatStatus.AVAILABLE.toString())))
+                .andExpect(jsonPath("$[1].seatNumber", is(2)))
+                .andExpect(jsonPath("$[1].seatStatus", is(SeatStatus.RESERVED.toString())))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -63,9 +64,11 @@ public class EventServiceTest {
         eventRepository.save(event);
 
         // when
-        EventResponseDto responseDto = eventService.getEventById(event.getId());
+        Optional<EventResponseDto> optionalResponseDto = eventService.getEventById(event.getId());
 
         // then
+        assertTrue(optionalResponseDto.isPresent());
+        EventResponseDto responseDto = optionalResponseDto.get(); // Optional에서 값 추출
         assertNotNull(responseDto);
         assertEquals(event.getTitle(), responseDto.getTitle());
         assertEquals(event.getTicketOpenTime(), responseDto.getTicketOpenTime());
@@ -77,12 +80,12 @@ public class EventServiceTest {
         // given
         Long nonExistentId = 999L;
 
-        // when & then
-        NoSuchElementException exception = assertThrows(NoSuchElementException.class, () -> {
-            eventService.getEventById(nonExistentId);
-        });
+        // when
+        Optional<EventResponseDto> result = eventService.getEventById(nonExistentId);
 
-        assertEquals("Event not found with id " + nonExistentId, exception.getMessage());
+        // then
+        assertTrue(result.isEmpty(), "이벤트가 존재하지 않아야 합니다.");
+
     }
 
     @Test

--- a/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
@@ -1,8 +1,12 @@
 package com.example.goorm_ticket.api.event.service;
 
 import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
+import com.example.goorm_ticket.domain.event.dto.SeatResponseDto;
 import com.example.goorm_ticket.domain.event.entity.Event;
+import com.example.goorm_ticket.domain.event.entity.Seat;
+import com.example.goorm_ticket.domain.event.entity.SeatStatus;
 import com.example.goorm_ticket.domain.event.repository.EventRepository;
+import com.example.goorm_ticket.domain.event.repository.SeatRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,8 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -29,10 +34,8 @@ public class EventServiceTest {
     @Autowired
     private EventRepository eventRepository;
 
-//    @BeforeEach
-//    void setUp() {
-//
-//    }
+    @Autowired
+    private SeatRepository seatRepository;
 
     @Test
     @DisplayName("이벤트 목록을 모두 조회한다")
@@ -51,6 +54,72 @@ public class EventServiceTest {
         assertEquals("Test Event1", eventResponseDtos.getContent().get(0).getTitle());
         assertEquals("Test Event2", eventResponseDtos.getContent().get(1).getTitle());
     }
+
+    @Test
+    @DisplayName("특정 ID로 공연 상세정보를 성공적으로 조회한다.")
+    void getEventById_Success() {
+        //given
+        Event event = createEvent("Test Event");
+        eventRepository.save(event);
+
+        // when
+        EventResponseDto responseDto = eventService.getEventById(event.getId());
+
+        // then
+        assertNotNull(responseDto);
+        assertEquals(event.getTitle(), responseDto.getTitle());
+        assertEquals(event.getTicketOpenTime(), responseDto.getTicketOpenTime());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 이벤트 조회 시 예외가 발생한다.")
+    void getEventById_EventNotFound() {
+        // given
+        Long nonExistentId = 999L;
+
+        // when & then
+        NoSuchElementException exception = assertThrows(NoSuchElementException.class, () -> {
+            eventService.getEventById(nonExistentId);
+        });
+
+        assertEquals("Event not found with id " + nonExistentId, exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("특정 이벤트의 전체 좌석을 조회한다.")
+    void getSeatsByEventId() {
+        //given
+        Event event = createEvent("Test Event");
+        eventRepository.save(event);
+
+        // 테스트용 좌석 저장
+        Seat seat1 = Seat.builder()
+                .seatNumber(1L)
+                .seatSection("A")
+                .seatStatus(SeatStatus.AVAILABLE)
+                .event(event)
+                .build();
+
+        Seat seat2 = Seat.builder()
+                .seatNumber(2L)
+                .seatSection("A")
+                .seatStatus(SeatStatus.RESERVED)
+                .event(event)
+                .build();
+        seatRepository.saveAll(List.of(seat1, seat2));
+
+        // when
+        List<SeatResponseDto> seats = eventService.getSeatsByEventId(event.getId());
+
+        // then
+        assertNotNull(seats);
+        assertEquals(2, seats.size());  // 좌석이 2개인 것을 검증
+        assertEquals(1L, seats.get(0).getSeatNumber());  // 첫 번째 좌석 번호가 1인지 검증
+        assertEquals(SeatStatus.AVAILABLE, seats.get(0).getSeatStatus());  // 첫 번째 좌석 상태가 AVAILABLE인지 검증
+        assertEquals(2L, seats.get(1).getSeatNumber());  // 두 번째 좌석 번호가 2인지 검증
+        assertEquals(SeatStatus.RESERVED, seats.get(1).getSeatStatus());  // 두 번째 좌석 상태가 RESERVED인지 검증
+    }
+
 
     private Event createEvent(String title) {
         return Event.builder()

--- a/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.goorm_ticket.api.event.service;
+
+import com.example.goorm_ticket.domain.event.dto.EventResponseDto;
+import com.example.goorm_ticket.domain.event.entity.Event;
+import com.example.goorm_ticket.domain.event.repository.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional  // 테스트가 끝나면 데이터베이스 롤백
+public class EventServiceTest {
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+//    @BeforeEach
+//    void setUp() {
+//
+//    }
+
+    @Test
+    @DisplayName("이벤트 목록을 모두 조회한다")
+    void getAllEvents() {
+        //given
+        Event event1 = createEvent("Test Event1");
+        Event event2 = createEvent("Test Event2");
+
+        eventRepository.saveAll(List.of(event1, event2));
+
+        // when
+        Page<EventResponseDto> eventResponseDtos = eventService.getAllEvents(0, 10);
+
+        // then
+        assertEquals(2, eventResponseDtos.getTotalElements());
+        assertEquals("Test Event1", eventResponseDtos.getContent().get(0).getTitle());
+        assertEquals("Test Event2", eventResponseDtos.getContent().get(1).getTitle());
+    }
+
+    private Event createEvent(String title) {
+        return Event.builder()
+                .title(title)
+                .artist("artist")
+                .description("description")
+                .duration("9/28~9/30")
+                .venue("venue")
+                .ticketPrice(10000)
+                .ticketOpenTime(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
@@ -59,16 +59,14 @@ public class EventServiceTest {
     @Test
     @DisplayName("특정 ID로 공연 상세정보를 성공적으로 조회한다.")
     void getEventById_Success() {
-        //given
+        // given
         Event event = createEvent("Test Event");
         eventRepository.save(event);
 
         // when
-        Optional<EventResponseDto> optionalResponseDto = eventService.getEventById(event.getId());
+        EventResponseDto responseDto = eventService.getEventById(event.getId());
 
         // then
-        assertTrue(optionalResponseDto.isPresent());
-        EventResponseDto responseDto = optionalResponseDto.get(); // Optional에서 값 추출
         assertNotNull(responseDto);
         assertEquals(event.getTitle(), responseDto.getTitle());
         assertEquals(event.getTicketOpenTime(), responseDto.getTicketOpenTime());
@@ -80,12 +78,12 @@ public class EventServiceTest {
         // given
         Long nonExistentId = 999L;
 
-        // when
-        Optional<EventResponseDto> result = eventService.getEventById(nonExistentId);
+        // when & then
+        NoSuchElementException exception = assertThrows(NoSuchElementException.class, () -> {
+            eventService.getEventById(nonExistentId);
+        });
 
-        // then
-        assertTrue(result.isEmpty(), "이벤트가 존재하지 않아야 합니다.");
-
+        assertEquals("이벤트를 찾지 못했습니다. eventId: " + nonExistentId, exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
### 주요 변경 사항
EventService 클래스 추가:
- 이벤트 목록 조회, 이벤트 상세 조회 및 좌석 조회 기능 구현
- DTO 변환 로직을 별도로 분리하여 코드 중복 최소화

EventController 클래스 추가:
- 이벤트 목록 조회, 상세 정보 조회 및 좌석 조회 엔드포인트 구현
- 이벤트 ID 유효성 검사로 예외 처리

Seat 엔티티 수정 사항
- Order의 null을 허용하도록  nullable = false 삭제: 좌석이 예약되지 않은 초기 상태에서는 order가 null상태임

### 구현한 API
- GET /events: 모든 이벤트 목록 조회
- GET /events/{eventId}: 특정 이벤트 상세 조회
- GET /events/{eventId}/seats: 특정 이벤트의 좌석 정보 조회

### 테스트
- 단위 테스트 및 통합 테스트 추가: EventService 및 EventController의 메소드 검증

### 궁금한 점
- Event 엔티티에 String 타입의 duration 컬럼이 있는데, 이거는 공연 기간 날짜를 말하는 걸까요? 이대로 둬도 되는지, 아니면 시작 날짜, 종료 날짜 컬럼을 나눠서 추가해야 할지.
- Event 엔티티에 ticketCloseTime도 있어야 하지 않나요?