### PR TITLE
Event 관련 테스트가 동작하지 않는 버그 수정

### DIFF
--- a/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/controller/EventControllerTest.java
@@ -7,10 +7,13 @@ import com.example.goorm_ticket.domain.event.entity.SeatStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -28,7 +31,9 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(EventController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
 //컨트롤러 통합테스트
 class EventControllerTest {
 

--- a/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/goorm_ticket/api/event/service/EventServiceTest.java
@@ -123,7 +123,7 @@ public class EventServiceTest {
 
 
     private Event createEvent(String title) {
-        return Event.of(title, "artist", "description", "9/28~9/30", "venue", 10000, LocalDateTime.now());
+        return Event.of( "artist", title, "description", "9/28~9/30", "venue", 10000, LocalDateTime.now());
     }
 
 }


### PR DESCRIPTION
## 개요
main으로 병합되면서 Event 관련 테스트 코드가 실패하는 문제가 발생하여 수정하였습니다.

### 주요 변경 사항
1. **EventServiceTest의 createEvent 메서드 수정**
   - title과 artist 파라미터 순서가 잘못되어 테스트가 실패하는 문제를 해결하였습니다.
   - 올바른 순서로 변경: artist, title

2. **EventControllerTest 변경**
   - WebMvcTest 사용 시 오류가 발생하여 SpringBootTest로 변경하였습니다.
   - SpringBootTest로 변경 후 테스트가 정상적으로 작동합니다.

### 참고 사항
WebMvcTest의 오류 원인은 정확히 모르겠습니다...